### PR TITLE
Use `TransactionAwareCacheManagerProxy` when creating a `CacheManager`

### DIFF
--- a/spring-recipes-4th/ch07/recipe_7_7_i/src/main/java/com/apress/springrecipes/board/security/TodoAclConfig.java
+++ b/spring-recipes-4th/ch07/recipe_7_7_i/src/main/java/com/apress/springrecipes/board/security/TodoAclConfig.java
@@ -4,6 +4,7 @@ import javax.sql.DataSource;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.transaction.TransactionAwareCacheManagerProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.acls.AclEntryVoter;
@@ -39,8 +40,8 @@ public class TodoAclConfig {
     }
 
     @Bean
-    public EhCacheCacheManager ehCacheManagerFactoryBean() {
-        return new EhCacheCacheManager();
+    public CacheManager ehCacheManagerFactoryBean() {
+        return new TransactionAwareCacheManagerProxy(new EhCacheCacheManager());
     }
 
     @Bean


### PR DESCRIPTION
Since the contents of ACL DB and ACL Cache may be different when an ACL DB transaction is rolled back, I think that it would be better to wrap `TransactionAwareCacheManagerProxy` in `CacheManager` creation to update the ACL Cache only when an ACL DB transaction is committed.