### PR TITLE
Add RETURN_GENERATED_KEYS to receive auto-increment ID after INSERT

### DIFF
--- a/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/java/com/apress/springrecipes/caching/JdbcCustomerRepository.java
+++ b/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/java/com/apress/springrecipes/caching/JdbcCustomerRepository.java
@@ -2,6 +2,7 @@ package com.apress.springrecipes.caching;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -43,10 +44,10 @@ public class JdbcCustomerRepository implements CustomerRepository {
     @CachePut(value="customers", key = "#result.id")
     public Customer create(String name) {
 
-        final String sql = "INSERT INTO customer (name) VALUES (?);";
+        final String sql = "INSERT INTO customer (name) VALUES (?)";
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbc.update(con -> {
-            PreparedStatement ps = con.prepareStatement(sql);
+            PreparedStatement ps = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             ps.setString(1, name);
             return ps;
         }, keyHolder);

--- a/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/resources/schema.sql
+++ b/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
 CREATE TABLE customer (
   id bigint AUTO_INCREMENT PRIMARY KEY ,
-  name VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL
 );


### PR DESCRIPTION
hello.

In the example code, there is a problem where the auto-increment value cannot be retrieved after INSERT and is returned as null.

* https://github.com/Apress/spring-5-recipes/blob/5fc7cc9f3e97b2486541caa1ae8bf5a95c03152b/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/java/com/apress/springrecipes/caching/JdbcCustomerRepository.java#L46-L54

So, I added Statement.RETURN_GENERATED_KEYS as the second parameter when running prepareStatement().

I also corrected what appeared to be simple typos.

* https://github.com/Apress/spring-5-recipes/blob/5fc7cc9f3e97b2486541caa1ae8bf5a95c03152b/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/resources/schema.sql#L3
  * Remove unnecessary commas at the end of column properties.
* https://github.com/Apress/spring-5-recipes/blob/5fc7cc9f3e97b2486541caa1ae8bf5a95c03152b/spring-recipes-4th/appendix-b/recipe_b_6_i/src/main/java/com/apress/springrecipes/caching/JdbcCustomerRepository.java#L46
  * Remove semicolon at the end of SQL statement.

thank you have a good day. 👍